### PR TITLE
Enable `bundled` feature for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ jq-sys = { version = "^0.2.0" }
 
 [dev-dependencies]
 serde_json = "1.0"
+
+[package.metadata.docs.rs]
+features = ["bundled"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ hints with the [jq-sys] crate on how to link.
 
 # Changelog
 
+## Unreleased
+
+- [#1] Enabled `bundled` feature when building on docs.rs.
+
 ## v0.2.0 (2019-02-18)
 
 - Updates [jq-sys] dep to v0.2.0 for better build controls.
@@ -95,3 +99,5 @@ Breaking Changes:
 ## v0.1.0 (2019-01-13)
 
 Initial release.
+
+[#1]: https://github.com/onelson/json-query/issues/1


### PR DESCRIPTION
closes #1, but we won't see it until the crate is published next. Will wait until onelson/jq-sys#1 and onelson/jq-sys#2 have been resolved.